### PR TITLE
Add basic input functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,161 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+

--- a/Husk/history.py
+++ b/Husk/history.py
@@ -1,0 +1,25 @@
+import os
+import contextlib
+
+from Husk import user_data
+
+
+@contextlib.contextmanager
+def History(*history_file_path):
+    if len(history_file_path) == 0:
+        raise ValueError('length of `history_file_path` can\'t be 0.')
+
+    os.makedirs(user_data.xdg_data(), exist_ok=True)
+
+    with open(user_data.xdg_data(*history_file_path), 'r') as f:
+        data = list(
+            hdr.replace('\n', '')
+            for hdr in f.readlines()
+            if hdr != '\n'
+        )
+
+    try:
+        yield data
+    finally:
+        with open(user_data.xdg_data(*history_file_path), 'w') as f:
+            f.write('\n'.join(data) + '\n')

--- a/Husk/user_data.py
+++ b/Husk/user_data.py
@@ -1,0 +1,16 @@
+import os.path
+
+
+# This file is part of `babi` which is released under MIT.
+# Go to https://github.com/asottile/babi/blob/main/LICENSE for full license details.
+
+
+def _xdg(*path, env, default):
+    return os.path.join(
+        os.environ.get(env) or os.path.expanduser(default),
+        'husk', *path
+    )
+
+
+def xdg_data(*path):
+    return _xdg(*path, env='XDG_DATA_HOME', default='~/.local/share')

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,10 @@ setup(
             'husk=Husk.husk:main'
         ]
     },
-    packages=find_packages()
+    packages=find_packages(),
+    install_requires=[
+        'readchar'
+    ],
+    python_requires='>=3.8'
 )
 


### PR DESCRIPTION
- add a `.gitignore`, making pushing to remote easier
- add a context manager named `History` to ensure correct writing to history file. (Doesn't work on `^C` yet)
- moved existence of history file to a convenient path and enable through `_xdg` that there can be stored more user data (like hashed passwords or username, etc...)
- added `readchar` as a dependency in installation and specifying minimum python version (Personal choice: 3.8 cause i used some techniques introduced in this version, could theoretically be changed to also support 3.7 and eventually lower)
- removed `input-history.txt` as it is no longer needed
- added `husk_input` for input handling
- reworked `main` to work with the changes