### PR TITLE
Add tests and fix a little bug

### DIFF
--- a/Husk/husk.py
+++ b/Husk/husk.py
@@ -117,6 +117,10 @@ def husk_input(history_data):
             cursor_pos = len(command)
             print(command, end='', flush=True)
             continue
+        elif key == '\t':
+            cursor_pos += 4
+            key = key.expandtabs(4)
+            command += '    '
         else:
             cursor_pos += 1
             command += key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+
+import pytest
+
+
+@pytest.fixture
+def history_file(tmp_path):
+    history_file = tmp_path / 'husk'
+    history_file.mkdir(parents=True, exist_ok=True)
+    history_file /= '.history'
+    history_file.touch()
+    return history_file
+
+
+@pytest.fixture
+def chdir_safe_path(tmp_path):
+    current_path = os.getcwd()
+    yield tmp_path
+    os.chdir(current_path)

--- a/tests/errorcodes_test.py
+++ b/tests/errorcodes_test.py
@@ -1,0 +1,16 @@
+from Husk.errorcodes import Syntax_Error
+from Husk.errorcodes import User_Auth_Error1
+
+
+def test_user_auth_error1(capsys):
+    User_Auth_Error1()
+    out, err = capsys.readouterr()
+    assert out == 'Husk Error 01: The entered passwords do not match please try again\n'
+    assert err == ''
+
+
+def test_syntax_error(capsys):
+    Syntax_Error()
+    out, err = capsys.readouterr()
+    assert out == 'Husk Error 02: SYNTAX ERROR\n'
+    assert err == ''

--- a/tests/history_test.py
+++ b/tests/history_test.py
@@ -1,0 +1,65 @@
+import os
+from unittest import mock
+
+import pytest
+
+from Husk.history import History
+
+
+def test_history_file_doesnt_exist(tmp_path):
+    with mock.patch.dict(os.environ, {'XDG_DATA_HOME': str(tmp_path)}):
+        with History('.history') as data:
+            ...
+
+        assert data == []
+
+
+def test_empty_history_file(tmp_path):
+    with mock.patch.dict(os.environ, {'XDG_DATA_HOME': str(tmp_path)}):
+
+        with History('.history') as data:
+            ...
+
+        assert data == []
+
+
+def test_history_file(tmp_path, history_file):
+    with mock.patch.dict(os.environ, {'XDG_DATA_HOME': str(tmp_path)}):
+        with open(str(history_file), 'w') as f:
+            f.write('ls\n-h\ncd\n')
+
+        with History('.history') as data:
+            ...
+
+        assert data == ['ls', '-h', 'cd']
+
+
+def test_history_file_with_empty_lines(tmp_path, history_file):
+    with mock.patch.dict(os.environ, {'XDG_DATA_HOME': str(tmp_path)}):
+        with open(history_file, 'w') as f:
+            f.write('ls\n-h\n\n\ncd\n')
+
+        with History('.history') as data:
+            ...
+
+        assert data == ['ls', '-h', 'cd']
+
+
+def test_history_file_correct_write(tmp_path):
+    with mock.patch.dict(os.environ, {'XDG_DATA_HOME': str(tmp_path)}):
+        with History('.history') as data:
+            assert data == []
+
+            data.extend(('ls', '-h', 'cd'))
+
+        with open(tmp_path / 'husk/.history', 'r') as f:
+            assert f.read() == 'ls\n-h\ncd\n'
+
+
+def test_history_path_not_present():
+    with pytest.raises(
+            ValueError,
+            match='length of `history_file_path` can\'t be 0.'
+    ):
+        with History():
+            ...

--- a/tests/husk/execute_command_test.py
+++ b/tests/husk/execute_command_test.py
@@ -1,0 +1,50 @@
+import pytest
+
+from Husk.husk import execute_command
+
+
+def test_unknown_command(capsys):
+    execute_command('some-non-existing-commmand')
+    out, err = capsys.readouterr()
+    assert out == 'Husk: command not found: some-non-existing-commmand\n'
+    assert err == ''
+
+
+@pytest.mark.parametrize(
+    ('command',),
+    (('cd',), ('ls',), ('sh',), ('cd -',), ('echo 1',))
+)
+def test_known_command(command, capsys):
+    execute_command(command)
+    out, err = capsys.readouterr()
+    assert out != f'Husk: command not found: {command}'
+    assert err == ''
+
+
+@pytest.mark.parametrize(
+    ('command',),
+    (('ls | echo',), ('ls | ls | echo',))
+)
+def test_command_with_pipes(command):
+    execute_command(command)
+
+
+@pytest.mark.parametrize(
+    ('command', 'output'),
+    (
+        (
+            'ls | some-non-existing-command',
+            'psh: command not found: some-non-existing-command\n'
+        ),
+        (
+            'non-existing-command | other-non-existing-command',
+            'psh: command not found: non-existing-command\npsh: '
+                'command not found: other-non-existing-command\n'
+        )
+    )
+)
+def test_unknown_commands_with_pipes(command, output, capsys):
+    execute_command(command)
+    out, err = capsys.readouterr()
+    assert out == output
+    assert err == ''

--- a/tests/husk/husk_cd_test.py
+++ b/tests/husk/husk_cd_test.py
@@ -1,0 +1,15 @@
+import os
+
+from Husk.husk import Husk_cd
+
+
+def test_husk_cd_existing_directory(chdir_safe_path):
+    Husk_cd(chdir_safe_path)
+    assert os.getcwd() == str(chdir_safe_path)
+
+
+def test_husk_cd_non_existing_directory(capsys):
+    Husk_cd('/definitely/not/existing/path')
+    out, err = capsys.readouterr()
+    assert out == 'cd: no such file or directory: /definitely/not/existing/path\n'
+    assert err == ''

--- a/tests/husk/husk_help_test.py
+++ b/tests/husk/husk_help_test.py
@@ -1,0 +1,16 @@
+from Husk.husk import Husk_help
+
+
+def test_husk_help(capsys):
+    Husk_help()
+    out, err = capsys.readouterr()
+    assert out == (
+        'Husk: shell written in Python. use the \'-h\' command for help\n'
+        'You can use the following commands within Husk:\n'
+        '    \n'
+        '    -h for help\n'
+        '    ls to list files\n'
+        '    rm to remove a file/directory\n'
+        '    \n'
+    )
+    assert err == ''

--- a/tests/user_data_test.py
+++ b/tests/user_data_test.py
@@ -1,0 +1,20 @@
+import os
+from unittest import mock
+
+from Husk.user_data import xdg_data
+
+
+def test_xdg_data_home_set():
+    with mock.patch.dict(os.environ, {'XDG_DATA_HOME': '/some/path/to/data'}):
+        ret = xdg_data('history', 'today')
+    assert ret == '/some/path/to/data/husk/history/today'
+
+
+def test_xdg_data_home_not_set():
+    def mock_expanduser(s):
+        return s.replace('~', '/home/username')
+
+    with mock.patch.object(os.path, 'expanduser', mock_expanduser):
+        with mock.patch.dict(os.environ, clear=True):
+            ret = xdg_data('history', 'today')
+        assert ret == '/home/username/.local/share/husk/history/today'


### PR DESCRIPTION
Add Tests for almost everything, but not for the input as this seems hardly possible.
Fix a little bug identified in the input functionality (tabs were printed as `\t`, which caused problems when deleting). 